### PR TITLE
Feature: Added installation and start-up scripts for HPC Greene using a Singularity image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,15 @@ poetry.lock
 
 # wandb
 wandb
+
+# Virtual env files
+.venv
+
+# HPC image files
+overlay-*
+nocturne.sif
+
+# Files used for package installation
+setup.py
+*.whl
+*.tar.gz

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ env.close()
 |                                        |                                                            |       |                    |                                                                                                                                                                        |
 
 ## Installation
+The instructions for installing Nocturne locally are provided below. To use the package on a HPC (e.g. HPC Greene), follow the instructions in [./hpc/hpc_setup.md](./hpc/hpc_setup.md).
 
 ### Requirements
 

--- a/hpc/hpc_setup.md
+++ b/hpc/hpc_setup.md
@@ -1,0 +1,38 @@
+## Setup of `nocturne_lab` on HPC
+
+### Installation (only do the first time)
+
+1. Clone repo into HPC Greene at location `/scratch/$USER`, where `$USER` is your netid.
+2. Move into `nocturne_lab` folder by running: `cd nocturne_lab`
+3. Set up Singularity image: `bash ./hpc/launch_image.sh`
+4. Create a virtual Python environment: `python3 -m venv .venv`
+5. Activate venv: `source .venv/bin/activate`
+6. Install Nocturne: `bash ./hpc/post_setup_image.sh`
+7. Restart Singularity image: `exit` 
+8. Relaunch image: `bash ./hpc/launch_image.sh`
+9. Check if Nocturne is properly installed: 
+    - (a) launch a Python shell
+    - (b) import Nocturne by running `import nocturne; import nocturne_cpp`
+
+### Usage
+
+Request an interactive compute node:
+```shell
+# Example: Request a single GPU for one hour
+srun --nodes=1 --tasks-per-node=1 --cpus-per-task=1 --mem=10GB --gres=gpu:1 --time=1:00:00 --pty /bin/bash
+```
+
+Navigate to the repo:
+```shell
+cd /scratch/$USER/nocturne_lab
+```
+
+Launch the Singularity image:
+```shell
+bash ./hpc/launch_image.sh
+```
+
+Activate the Python virtual environment:
+```shell
+source .venv/bin/activate
+```

--- a/hpc/launch_image.sh
+++ b/hpc/launch_image.sh
@@ -1,0 +1,62 @@
+# Script for launching the singularity image for Nocturne (lab version)
+# ---
+# Note: Script must be run from the Nocturne LAB repository (i.e. /scratch/$USER/nocturne_lab/)
+# and executed each time you want to use Nocturne (lab version) on the HPC (e.g. Greene).
+
+# Constants
+PROJECT="Nocturne (lab version)"
+PROJECT_DOCKER=docker://daphnecor/nocturne
+SINGULARITY_IMAGE=./hpc/nocturne.sif
+OVERLAY_LOC=/scratch/work/public/overlay-fs-ext3
+OVERLAY_FILE=./hpc/overlay-15GB-500K.ext3
+
+# Override WandB and pre-commit cache directories to avoid # files constraint issues
+WANDB_CACHE_DIR='${WANDB_CACHE_DIR}'
+PRE_COMMIT_CACHE = '${PRE_COMMIT_CACHE}'
+
+# Check if singularity image exists, if not pull Singularity image from Docker Hub
+if [ ! -f "${SINGULARITY_IMAGE}" ]; then
+    echo "Pulling Docker container from ${PROJECT_DOCKER}"
+    singularity pull $SINGULARITY_IMAGE $PROJECT_DOCKER
+fi
+
+# Check if overlay file exists, if not create it
+if [ ! -f "${OVERLAY_FILE}" ]; then  # Overlay file does not exist
+    echo "Setting up ${PROJECT_DOCKER} with initial overlay ${OVERLAY_FILE}.gz"
+
+    if [ ! -f "${OVERLAY_FILE}.gz" ]; then  # Overlay file has not been copied yet
+        echo "Copying overlay ${OVERLAY_FILE}.gz from ${OVERLAY_LOC}..."
+        cp -rp "${OVERLAY_LOC}/${OVERLAY_FILE}.gz" . -n
+        echo "Unzipping overlay ${OVERLAY_FILE}.gz..."
+        gunzip "${OVERLAY_FILE}.gz" -n
+    fi
+
+    # Launch singularity for the first time
+    echo 'Launching singularity image in WRITE (edit) mode...'
+
+    # Welcome message
+    echo "Run the following to initialize ${PROJECT}:"
+    echo "  (1) create a virtual Python environment: 'python3 -m venv .venv'"
+    echo "  (2) activate venv: 'source .venv/bin/activate'"
+    echo "  (3) install Nocturne: 'bash ./hpc/post_setup_image.sh'"
+
+    # Launch singularity image in write mode
+    singularity exec --nv --overlay "${OVERLAY_FILE}:rw" \
+        "${SINGULARITY_IMAGE}" \
+        /bin/bash
+
+else  # Overlay Singularity image and overlay file exist
+
+    # Launch singularity
+    echo 'Launching singularity image in OVERLAY (use) mode...'
+
+    # Welcome message
+    echo "Run the following to activate the Python environment:"
+    echo "  (1) activate venv: 'source venv/bin/activate'"
+
+    # Launch singularity image in use mode
+    singularity exec --nv --overlay "${OVERLAY_FILE}:ro" \
+        "${SINGULARITY_IMAGE}" \
+        /bin/bash
+
+fi

--- a/hpc/launch_image.sh
+++ b/hpc/launch_image.sh
@@ -10,10 +10,6 @@ SINGULARITY_IMAGE=./hpc/nocturne.sif
 OVERLAY_LOC=/scratch/work/public/overlay-fs-ext3
 OVERLAY_FILE=./hpc/overlay-15GB-500K.ext3
 
-# Override WandB and pre-commit cache directories to avoid # files constraint issues
-WANDB_CACHE_DIR='${WANDB_CACHE_DIR}'
-PRE_COMMIT_CACHE = '${PRE_COMMIT_CACHE}'
-
 # Check if singularity image exists, if not pull Singularity image from Docker Hub
 if [ ! -f "${SINGULARITY_IMAGE}" ]; then
     echo "Pulling Docker container from ${PROJECT_DOCKER}"

--- a/hpc/launch_image.sh
+++ b/hpc/launch_image.sh
@@ -8,7 +8,7 @@ PROJECT="Nocturne (lab version)"
 PROJECT_DOCKER=docker://daphnecor/nocturne
 SINGULARITY_IMAGE=./hpc/nocturne.sif
 OVERLAY_LOC=/scratch/work/public/overlay-fs-ext3
-OVERLAY_FILE=./hpc/overlay-15GB-500K.ext3
+OVERLAY_FILE=overlay-15GB-500K.ext3
 
 # Check if singularity image exists, if not pull Singularity image from Docker Hub
 if [ ! -f "${SINGULARITY_IMAGE}" ]; then
@@ -48,10 +48,10 @@ else  # Overlay Singularity image and overlay file exist
 
     # Welcome message
     echo "Run the following to activate the Python environment:"
-    echo "  (1) activate venv: 'source venv/bin/activate'"
+    echo "  (1) activate venv: 'source .venv/bin/activate'"
 
     # Launch singularity image in use mode
-    singularity exec --nv --overlay "${OVERLAY_FILE}:ro" \
+    singularity exec --nv --overlay "${OVERLAY_FILE}:rw" \
         "${SINGULARITY_IMAGE}" \
         /bin/bash
 

--- a/hpc/post_setup_image.sh
+++ b/hpc/post_setup_image.sh
@@ -1,0 +1,18 @@
+# Script for installing Nocturne (lab version) and dependencies in Singularity image
+# ---
+# Note: Script must be run from the Nocturne LAB repository (i.e. /scratch/$USER/nocturne_lab/)
+# and only once after running 'bash ./hpc/launch_image.sh' for the first time.
+
+# Install requirements before installing Nocturne
+echo 'Installing installation dependencies: pip, poetry, and linking git submodules...'
+pip install -U pip poetry
+git submodule sync
+git submodule update --init --recursive
+
+# Install Nocturne
+echo 'Installing Nocturne using poetry...'
+poetry install --all-extras
+echo "Successfully installed Nocturne. Please relaunch the Singularity image by running: 'bash ./hpc/launch_image.sh'"
+
+# Exit Singularity image
+exit

--- a/hpc/post_setup_image.sh
+++ b/hpc/post_setup_image.sh
@@ -11,8 +11,9 @@ git submodule update --init --recursive
 
 # Install Nocturne
 echo 'Installing Nocturne using poetry...'
+poetry build  # Note: Build first to see build outputs. If build gets stuck at 38%, increase RAM.
+rm setup.py
 poetry install --all-extras
-echo "Successfully installed Nocturne. Please relaunch the Singularity image by running: 'bash ./hpc/launch_image.sh'"
-
-# Exit Singularity image
-exit
+echo "Successfully installed Nocturne."
+echo "To use Nocturne, please close the current Singularity image by running \
+  'exit' and afterwards relaunch the image by running 'bash ./hpc/launch_image.sh'"


### PR DESCRIPTION
## Description

This pull requests adds bash scripts for the installation and launching on HPC Greene using a Singularity image.

## Changes Made

The following changes were made in the `feature/add_hpc_setup_scripts` branch:

- [x] HPC Singularity image launch script:
    - [x] Create Singularity image by pulling the Docker image to be used for this project
    - [x] Copies over base overlay file for Singularity image
    - [x] Prepares overlay file to be edited and launches Singularity image in _write_ mode on first launch
    - [x] Launches Singularity image in _use_ mode after it has been installed
- [x] HPC initial installation of Nocturne script:
    - [x] Install project dependencies, i.e., (1) poetry and (2) git submodules for Nocturne
    - [x] Install Nocturne project using poetry

## Related Issues

This pull request resolves the no outstanding issues.

## Review checklist
- [x] Review file changes
- [x] Test scripts on HPC Greene:
    - [x] Clone repo into HCP Greene at location `/scratch/$USER`
    - [x] Move into `nocturne_lab` folder by running: `cd nocturne_lab`
    - [x] Set up Singularity image by running: `bash ./hpc/launch_image.sh`
    - [x] Create a virtual Python environment: `python3 -m venv .venv`
    - [x] Activate `venv` by running: `source .venv/bin/activate`
    - [x] Install Nocturne by running `bash ./hpc/post_setup_image.sh`
    - [x] Re-launch Singularity image by running: `bash ./hpc/launch_image.sh`
    - [x] Re-activate `venv` by running: `source .venv/bin/activate`
    - [x] Check if Nocturne is properly installed: (1) launch a Python shell by running `python` and (2) import Nocturne by running `import nocturne; import nocturne_cpp`